### PR TITLE
IIS website setting for http https redirect

### DIFF
--- a/installer/scripts/iis-redirect-http-https.bat
+++ b/installer/scripts/iis-redirect-http-https.bat
@@ -1,0 +1,7 @@
+C:\Windows\System32\inetsrv\appcmd.exe set config "Default Web Site" -section:system.webServer/rewrite/rules /-"[name='ELB_HTTP_redirect']" > C:\Windows\Temp\ELB_HTTP_redirect.log 2>&1
+C:\Windows\System32\inetsrv\appcmd.exe set config "Default Web Site" -section:system.webServer/rewrite/rules /+"[name='ELB_HTTP_redirect',enabled='true',stopProcessing='true']" >> C:\Windows\Temp\ELB_HTTP_redirect.log 2>&1
+C:\Windows\System32\inetsrv\appcmd.exe set config "Default Web Site" -section:system.webServer/rewrite/rules /"[name='ELB_HTTP_redirect'].match.url:"^^(.*)$"" >> C:\Windows\Temp\ELB_HTTP_redirect.log 2>&1
+C:\Windows\System32\inetsrv\appcmd.exe set config "Default Web Site" -section:system.webServer/rewrite/rules /+"[name='ELB_HTTP_redirect'].conditions.[input='{HTTP_X_FORWARDED_PROTO}',pattern='^https$',negate='true']" >> C:\Windows\Temp\ELB_HTTP_redirect.log 2>&1
+C:\Windows\System32\inetsrv\appcmd.exe set config "Default Web Site" -section:system.webServer/rewrite/rules /+"[name='ELB_HTTP_redirect'].conditions.[input='{HTTP_USER_AGENT}',pattern='ELB-HealthChecker',negate='true']" >> C:\Windows\Temp\ELB_HTTP_redirect.log 2>&1
+C:\Windows\System32\inetsrv\appcmd.exe set config "Default Web Site" -section:system.webServer/rewrite/rules /"[name='ELB_HTTP_redirect'].action.type:"Redirect"" /"[name='ELB_HTTP_redirect'].action.url:"https://{SERVER_NAME}{URL}"" >> C:\Windows\Temp\ELB_HTTP_redirect.log 2>&1
+iisreset >> C:\Windows\Temp\ELB_HTTP_redirect.log 2>&1

--- a/installer/scripts/postinstall.ps1
+++ b/installer/scripts/postinstall.ps1
@@ -16,7 +16,7 @@ Invoke-Expression -Command:"icacls C:/inetpub/AspNetCoreWebApps/winged-keys-app"
 #
 # Set IIS http to https
 #
-C:/inetpub/AspNetCoreWebApps/hedwig-spa/installer/scripts/iis-redirect-http-https.bat
+c:/inetpub/ASpNetCoreWebApps/winged-keys-app/installer/scripts/iis-redirect-http-https.bat
 
 #
 # Copy entity framework dll to web root

--- a/installer/scripts/postinstall.ps1
+++ b/installer/scripts/postinstall.ps1
@@ -14,6 +14,11 @@ Invoke-Expression -Command:"icacls C:/inetpub/AspNetCoreWebApps/winged-keys-app 
 Invoke-Expression -Command:"icacls C:/inetpub/AspNetCoreWebApps/winged-keys-app"
 
 #
+# Set IIS http to https
+#
+C:/inetpub/AspNetCoreWebApps/hedwig-spa/installer/scripts/iis-redirect-http-https.bat
+
+#
 # Copy entity framework dll to web root
 #
 Copy-Item -force C:/inetpub/AspNetCoreWebApps/winged-keys-app/installer/lib/ef.dll C:/inetpub/AspNetCoreWebApps/winged-keys-app/ef.dll


### PR DESCRIPTION
Please see issue #26

In order to redirecting HTTP traffic (port 80) to HTTPS (port 443) for a Beanstalk environment with an application load balancer, the security configuration of the IIS webserver needs to be updated using the commands in the following link as per AWS:

https://github.com/awsdocs/elastic-beanstalk-samples/blob/master/configuration-files/aws-provided/security-configuration/https-redirect/dotnet/https-redirect-load-balanced-dotnet.config

This fix is to track the IIS webserver change only. The DeveOps team will also need to switch the Beanstalk load balancer from classic to application via another issue.