### PR TITLE
added token for stdoutlogenabled

### DIFF
--- a/installer/iis/web.config
+++ b/installer/iis/web.config
@@ -5,7 +5,7 @@
       <handlers>
         <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
       </handlers>
-      <aspNetCore processPath="dotnet" arguments=".\WingedKeys.dll" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" />
+      <aspNetCore processPath="dotnet" arguments=".\WingedKeys.dll" stdoutLogEnabled="__StdoutLogEnabled__" stdoutLogFile=".\logs\stdout" />
     </system.webServer>
   </location>
 </configuration>


### PR DESCRIPTION
During the release pipeline execution, the published files are packaged and then deployed.  A packaging task copies the web.config file from installer\iis to the zip root.

To support tokenization, the web.config file was updated to have a token for the stdoutLogEnabled attribute.  This token is called __StdoutLogEnabled__.  

To replace this token during execution of the release pipeline, the following was done (tested in UAT):

a) a new market place task, Tokenizer, was installed for the Azure DevOps Services ctoec organization
  * https://marketplace.visualstudio.com/items?itemName=4tecture.Tokenizer

b) a variable was added to the UAT pipeline called __StdoutLogEnabled__
c) a tokenizer task was added to the UAT pipeline to perform the token replacement

Several deployments were performed to the UAT environment and the installation works with no issues.   With this implementation, we now have the ability to enable and disable the stdoutLogEnabled attribute via the pipeline. 

If this PR is approved, the following must be done prior to further deployments:

a) the variable StdoutLogEnabled needs to be added to the WingedKeys Staging pipeline
b) the tokenizer task needs to be added to the WingedKeys Staging pipeline
c) the variable StdoutLogEnabled needs to be added to the WingedKeys Prod pipeline
d) the tokenizer task needs to be added to the WingedKeys Prod pipeline
