### PR TITLE
Rework test user creation mechanism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
             cd src/WingedKeys
             aws secretsmanager get-secret-value --secret-id /ece/<< parameters.env >>/wingedkeys > secrets.json
             jq '.SecretString | fromjson' secrets.json > tmp.json && mv tmp.json secrets.json
+            cat secrets.json
             jq '.ConnectionStrings={ WINGEDKEYS: ."ConnectionStrings.WINGEDKEYS" }' secrets.json > tmp.json && mv tmp.json secrets.json
             jq 'del(.["ConnectionStrings.WINGEDKEYS"])' secrets.json > tmp.json && mv tmp.json secrets.json
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,6 @@ jobs:
             cd src/WingedKeys
             aws secretsmanager get-secret-value --secret-id /ece/<< parameters.env >>/wingedkeys > secrets.json
             jq '.SecretString | fromjson' secrets.json > tmp.json && mv tmp.json secrets.json
-            cat secrets.json
             jq '.ConnectionStrings={ WINGEDKEYS: ."ConnectionStrings.WINGEDKEYS" }' secrets.json > tmp.json && mv tmp.json secrets.json
             jq 'del(.["ConnectionStrings.WINGEDKEYS"])' secrets.json > tmp.json && mv tmp.json secrets.json
       - run:

--- a/src/WingedKeys/Data/DatabaseInitializer.cs
+++ b/src/WingedKeys/Data/DatabaseInitializer.cs
@@ -13,7 +13,7 @@ namespace WingedKeys.Data
 	{
 		private static readonly string TEST_USER_ID = "2c0ec653-8829-4aa1-82ba-37c8832bbb88";
 
-		public static async void Initialize(
+		public static void Initialize(
 			PersistedGrantDbContext persistedGrantDbContext,
 			ConfigurationDbContext configurationDbContext,
 			WingedKeysContext wingedKeysContext,
@@ -30,7 +30,8 @@ namespace WingedKeys.Data
 			AddIdentityResources(config, configurationDbContext);
 			AddApiResources(config, configurationDbContext);
 
-			if ((await userMgr.FindByIdAsync(DatabaseInitializer.TEST_USER_ID)) == null)
+			var testAdminUser = userMgr.FindByIdAsync(DatabaseInitializer.TEST_USER_ID).Result;
+			if (testAdminUser == null)
 			{
 				AddTestApplicationAdminUser(userMgr);
 			}

--- a/src/WingedKeys/Data/DatabaseInitializer.cs
+++ b/src/WingedKeys/Data/DatabaseInitializer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Configuration;
 using IdentityServer4.EntityFramework.DbContexts;
 using IdentityServer4.EntityFramework.Mappers;
 using IdentityModel;
@@ -18,7 +19,9 @@ namespace WingedKeys.Data
 			ConfigurationDbContext configurationDbContext,
 			WingedKeysContext wingedKeysContext,
 			UserManager<ApplicationUser> userMgr,
-			Config config)
+			Config config,
+			IConfiguration configuration
+			)
 		{
 			persistedGrantDbContext.Database.EnsureCreated();
 			configurationDbContext.Database.EnsureCreated();
@@ -33,7 +36,7 @@ namespace WingedKeys.Data
 			var testAdminUser = userMgr.FindByIdAsync(DatabaseInitializer.TEST_USER_ID).Result;
 			if (testAdminUser == null)
 			{
-				AddTestApplicationAdminUser(userMgr);
+				AddTestApplicationAdminUser(userMgr, configuration.GetValue<string>("AdminPassword"));
 			}
 		}
 
@@ -71,7 +74,8 @@ namespace WingedKeys.Data
 		}
 
 		private static void AddTestApplicationAdminUser(
-			UserManager<ApplicationUser> userMgr
+			UserManager<ApplicationUser> userMgr,
+            string password
 		)
 		{
 			var voldemort = new ApplicationUser
@@ -81,7 +85,7 @@ namespace WingedKeys.Data
 				Email = "voldemort@hogwarts.uk.co",
 				EmailConfirmed = true
 			};
-			var result = userMgr.CreateAsync(voldemort, "thechosenone").Result;
+			var result = userMgr.CreateAsync(voldemort, password).Result;
 			if (!result.Succeeded)
 			{
 					throw new Exception(result.Errors.First().Description);

--- a/src/WingedKeys/Program.cs
+++ b/src/WingedKeys/Program.cs
@@ -41,7 +41,7 @@ namespace WingedKeys
 						var userMgr = services.GetRequiredService<UserManager<ApplicationUser>>();
 						var configuration = services.GetRequiredService<IConfiguration>();
 						var config = new Config(configuration);
-						DatabaseInitializer.Initialize(persistedGrantDbContext, configurationDbContext, wingedKeysContext, userMgr, config);
+						DatabaseInitializer.Initialize(persistedGrantDbContext, configurationDbContext, wingedKeysContext, userMgr, config, configuration);
 						logger.LogInformation("Database initialization complete");
 					}
 					catch (Exception ex)

--- a/src/WingedKeys/Quickstart/Home/HomeController.cs
+++ b/src/WingedKeys/Quickstart/Home/HomeController.cs
@@ -29,14 +29,13 @@ namespace IdentityServer4.Quickstart.UI
 
         public IActionResult Index()
         {
-            if (_environment.IsDevelopment())
+            if (!_environment.IsProduction())
             {
-                // only show in development
                 return View();
             }
 
             _logger.LogInformation("Homepage is disabled in production. Returning 404.");
-            return Ok();
+            return NotFound();
         }
 
         /// <summary>

--- a/src/WingedKeys/Views/Shared/_Layout.cshtml
+++ b/src/WingedKeys/Views/Shared/_Layout.cshtml
@@ -35,16 +35,24 @@
                     </span>
                 </a>
             </div>
-
             @if (!string.IsNullOrWhiteSpace(name))
             {
                 <ul class="nav navbar-nav">
                     <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown">@name <b class="caret"></b></a>
                         <ul class="dropdown-menu">
-                            <li><a asp-action="Logout" asp-controller="Account">Logout</a></li>
+                            @if (User.IsInRole("admin"))
+                            {
+                                <li><a asp-action="NewAccount" asp-controller="Admin">Create User</a></li>
+                            }
+                            <li><a asp-action="Logout" asp-controller="Account">Log Out</a></li>
                         </ul>
                     </li>
+                </ul>
+            } else
+            {
+                <ul class="nav navbar-nav">
+                    <li><a asp-action="Login" asp-controller="Account">Log In</a></li>
                 </ul>
             }
         </div>

--- a/src/WingedKeys/appsettings.json
+++ b/src/WingedKeys/appsettings.json
@@ -1,5 +1,6 @@
 {
   "AccessTokenLifetime": "360000",
+  "AdminPassword": "thechosenone",
   "AllowedHosts": "*",
   "BaseUri": "https://localhost:5050",
   "CertificateFileName": "",


### PR DESCRIPTION
### Summary
This PR stops WingedKeys from removing all user data from the db on deploy of all non-prod environments, and instead only creates a default admin user if one is not already present.  It also adds `Log In` and `Create User` components to the navbar (the latter exclusively for admin users) so that user creation is a bit more accessible in non-prod environments.

### Associated PRs
- https://github.com/ctoec/data-collection/pull/334
- https://github.com/skylight-hq/ctoec-devops/pull/89