### PR TITLE
Ensure admin credentials pulled from AWS are included in CircleCI deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
             jq '.Logging.LogLevel.System="Warning"' appsettings.json > temp.json && mv temp.json appsettings.json
             jq '.Logging.Region="us-east-2"' appsettings.json > temp.json && mv temp.json appsettings.json
 
-            # Remove from appsettings.json initially, as they will be replaced with the corresponding secrets pulled from AWs
+            # Remove from appsettings.json, as they will be replaced with the corresponding secrets pulled from AWs
             jq 'del(.AdminPassword)' appsettings.json > temp.json && mv temp.json appsettings.json
             jq 'del(.ConnectionStrings)' appsettings.json > temp.json && mv temp.json appsettings.json
             jq 'del(.CertificatePassword)' appsettings.json > temp.json && mv temp.json appsettings.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
             jq '.application="ece-wingedkeys-<< parameters.env >>-app"' aws-beanstalk-tools-defaults.json > temp.json && mv temp.json aws-beanstalk-tools-defaults.json
             jq '.environment="ece-wingedkeys-<< parameters.env >>-env"' aws-beanstalk-tools-defaults.json > temp.json && mv temp.json aws-beanstalk-tools-defaults.json
             jq '."instance-profile"="ece-wingedkeys-<< parameters.env >>-eb-ec2"' aws-beanstalk-tools-defaults.json > temp.json && mv temp.json aws-beanstalk-tools-defaults.json
-            cat src/WingedKeys/appsettings.json
+            cat appsettings.json
       - aws-s3/copy:
           from: 's3://ece-reporter-<< parameters.env >>-store/secrets/wingedkeys/<< parameters.env >>-wingedkeys.pfx'
           to: src/WingedKeys/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ jobs:
             jq '.application="ece-wingedkeys-<< parameters.env >>-app"' aws-beanstalk-tools-defaults.json > temp.json && mv temp.json aws-beanstalk-tools-defaults.json
             jq '.environment="ece-wingedkeys-<< parameters.env >>-env"' aws-beanstalk-tools-defaults.json > temp.json && mv temp.json aws-beanstalk-tools-defaults.json
             jq '."instance-profile"="ece-wingedkeys-<< parameters.env >>-eb-ec2"' aws-beanstalk-tools-defaults.json > temp.json && mv temp.json aws-beanstalk-tools-defaults.json
+            cat src/WingedKeys/appsettings.json
       - aws-s3/copy:
           from: 's3://ece-reporter-<< parameters.env >>-store/secrets/wingedkeys/<< parameters.env >>-wingedkeys.pfx'
           to: src/WingedKeys/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,6 @@ jobs:
             jq '.application="ece-wingedkeys-<< parameters.env >>-app"' aws-beanstalk-tools-defaults.json > temp.json && mv temp.json aws-beanstalk-tools-defaults.json
             jq '.environment="ece-wingedkeys-<< parameters.env >>-env"' aws-beanstalk-tools-defaults.json > temp.json && mv temp.json aws-beanstalk-tools-defaults.json
             jq '."instance-profile"="ece-wingedkeys-<< parameters.env >>-eb-ec2"' aws-beanstalk-tools-defaults.json > temp.json && mv temp.json aws-beanstalk-tools-defaults.json
-            cat appsettings.json
       - aws-s3/copy:
           from: 's3://ece-reporter-<< parameters.env >>-store/secrets/wingedkeys/<< parameters.env >>-wingedkeys.pfx'
           to: src/WingedKeys/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,8 @@ jobs:
             jq '.Logging.LogLevel.System="Warning"' appsettings.json > temp.json && mv temp.json appsettings.json
             jq '.Logging.Region="us-east-2"' appsettings.json > temp.json && mv temp.json appsettings.json
 
+            # Remove from appsettings.json initially, as they will be replaced with the corresponding secrets pulled from AWs
+            jq 'del(.AdminPassword)' appsettings.json > temp.json && mv temp.json appsettings.json
             jq 'del(.ConnectionStrings)' appsettings.json > temp.json && mv temp.json appsettings.json
             jq 'del(.CertificatePassword)' appsettings.json > temp.json && mv temp.json appsettings.json
       - run:


### PR DESCRIPTION
This PR updates the CircleCI deploy pipeline so that the `AdminPassword` parameter maintained in `appsettings.json` has it's value replaced with the _actual_ password stored in AWS Secrets Manager. 