### PR TITLE
Match updated secrets location

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           name: Download and Parse AWS Secrets
           command: |
             cd src/WingedKeys
-            aws secretsmanager get-secret-value --secret-id /ece/<< parameters.env >>/wingedkeys > secrets.json
+            aws secretsmanager get-secret-value --secret-id /ece/<< parameters.env >>/wingedkeys/admin > secrets.json
             jq '.SecretString | fromjson' secrets.json > tmp.json && mv tmp.json secrets.json
             jq '.ConnectionStrings={ WINGEDKEYS: ."ConnectionStrings.WINGEDKEYS" }' secrets.json > tmp.json && mv tmp.json secrets.json
             jq 'del(.["ConnectionStrings.WINGEDKEYS"])' secrets.json > tmp.json && mv tmp.json secrets.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
             jq '.environment="ece-wingedkeys-<< parameters.env >>-env"' aws-beanstalk-tools-defaults.json > temp.json && mv temp.json aws-beanstalk-tools-defaults.json
             jq '."instance-profile"="ece-wingedkeys-<< parameters.env >>-eb-ec2"' aws-beanstalk-tools-defaults.json > temp.json && mv temp.json aws-beanstalk-tools-defaults.json
       - aws-s3/copy:
-          from: 's3://ece-reporter-<< parameters.env >>-store/secrets/wingedkeys/<< parameters.env >>-wingedkeys.pfx'
+          from: 's3://ece-wingedkeys-<< parameters.env >>-store/secrets/wingedkeys/<< parameters.env >>-wingedkeys.pfx'
           to: src/WingedKeys/
       - add_ssh_keys
       - run:


### PR DESCRIPTION
PR to update the path where Winged Keys secrets are stored in CircleCI, so that deploys can continue without issue.  Said path was unfortunately necessarily updated in https://github.com/skylight-hq/ctoec-devops/pull/96.