### PR TITLE
Update JQ Dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,8 @@ jobs:
           name: 'Update Appsettings with environment specific variables'
           command: |
             jq --version
-            
+            jq --help
+
             cd src/WingedKeys
             jq '.AccessTokenLifetime="1800"' appsettings.json > temp.json && mv temp.json appsettings.json
             jq '.BaseUri="https://<< parameters.stage >>.ece-wingedkeys.ctoecskylight.com"' appsettings.json > temp.json && mv temp.json appsettings.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ jobs:
             # Remove from appsettings.json, as they will be replaced with the corresponding secrets pulled from AWS
             jq 'del(.AdminPassword)' appsettings.json > temp.json && mv temp.json appsettings.json
             jq 'del(.ConnectionStrings)' appsettings.json > temp.json && mv temp.json appsettings.json
+            cat appsettings.json
       - run:
           name: Merge Appsettings Config with AWS Secrets
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,6 @@ jobs:
             # Remove from appsettings.json, as they will be replaced with the corresponding secrets pulled from AWS
             jq 'del(.AdminPassword)' appsettings.json > temp.json && mv temp.json appsettings.json
             jq 'del(.ConnectionStrings)' appsettings.json > temp.json && mv temp.json appsettings.json
-            cat appsettings.json
       - run:
           name: Merge Appsettings Config with AWS Secrets
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,12 +39,11 @@ jobs:
             dotnet tool install --global Amazon.ElasticBeanstalk.Tools
             echo 'export PATH="$PATH:$HOME/.dotnet/tools/"' >> $BASH_ENV
       - run:
-          name: Install JQ 
+          name: Install JQ 1.6 from Source # Because apparently the '--rawfile' param isn't in Linux v1.5
           command: |
             wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
             chmod +x jq-linux64
             sudo mv jq-linux64 $(which jq)
-            jq --version
       - aws-cli/setup
       - run:
           name: Download and Parse AWS Secrets
@@ -63,9 +62,6 @@ jobs:
       - run:
           name: 'Update Appsettings with environment specific variables'
           command: |
-            jq --version
-            jq --help
-
             cd src/WingedKeys
             jq '.AccessTokenLifetime="1800"' appsettings.json > temp.json && mv temp.json appsettings.json
             jq '.BaseUri="https://<< parameters.stage >>.ece-wingedkeys.ctoecskylight.com"' appsettings.json > temp.json && mv temp.json appsettings.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
             wget https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
             chmod +x jq-linux64
             sudo mv jq-linux64 $(which jq)
+            jq --version
       - aws-cli/setup
       - run:
           name: Download and Parse AWS Secrets
@@ -62,6 +63,8 @@ jobs:
       - run:
           name: 'Update Appsettings with environment specific variables'
           command: |
+            jq --version
+            
             cd src/WingedKeys
             jq '.AccessTokenLifetime="1800"' appsettings.json > temp.json && mv temp.json appsettings.json
             jq '.BaseUri="https://<< parameters.stage >>.ece-wingedkeys.ctoecskylight.com"' appsettings.json > temp.json && mv temp.json appsettings.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,10 @@ jobs:
             echo 'export PATH="$PATH:$HOME/.dotnet/tools/"' >> $BASH_ENV
       - run:
           name: Install JQ 
-          command: sudo apt-get install jq
+          command: |
+            wget https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+            chmod +x jq-linux64
+            sudo mv jq-linux64 $(which jq)
       - aws-cli/setup
       - run:
           name: Download and Parse AWS Secrets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       - run:
           name: Install JQ 
           command: |
-            wget https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+            wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
             chmod +x jq-linux64
             sudo mv jq-linux64 $(which jq)
             jq --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
             dotnet tool install --global Amazon.ElasticBeanstalk.Tools
             echo 'export PATH="$PATH:$HOME/.dotnet/tools/"' >> $BASH_ENV
       - run:
-          name: Install JQ 1.6 from Source # Because apparently the '--rawfile' param isn't in Linux v1.5
+          name: Install JQ 1.6 from GitHub # Because apparently the '--rawfile' param isn't in Linux v1.5
           command: |
             wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
             chmod +x jq-linux64


### PR DESCRIPTION
We need to download the `jq` dependency from source because we need version 1.6 for Linux (which apparently is the version that includes the `--rawfile` param, according to a bunch of trial and error on my part), and apparently that version isn't available in the APT library with the version of Ubuntu we're currently running.