### PR TITLE
Update Sender Identity Domain for Reset Password Emails

### DIFF
--- a/src/WingedKeys/appsettings.json
+++ b/src/WingedKeys/appsettings.json
@@ -10,7 +10,7 @@
   "ConnectionStrings": {
     "WINGEDKEYS": "Server=(localdb)\\mssqllocaldb;Database=wingedkeys;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
-  "SendGridEmail": "no-reply@ctoecskylight.com",
+  "SendGridEmail": "no-reply@ctoec.org",
   "SendGridApiKey": "",
   "Logging": {
 		"Region": "",


### PR DESCRIPTION
Change from `ctoecskylight.com` to `ctoec.org`.