### PR TITLE
Remove all traces of Hedwig (ECE Reporter v1)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
             jq '.BaseUri="https://<< parameters.stage >>.ece-wingedkeys.ctoecskylight.com"' appsettings.json > temp.json && mv temp.json appsettings.json
             jq '.CertificateFileName="server.pfx"' appsettings.json > temp.json && mv temp.json appsettings.json
             jq --rawfile password password.txt '.CertificatePassword=($password | rtrimstr("\n"))' appsettings.json > temp.json && mv temp.json appsettings.json
-            jq '.ClientUris="<< parameters.additional-clients >>https://<< parameters.stage >>.ece-hedwig.ctoecskylight.com,https://localhost:5001,https://<< parameters.stage >>.ece-fawkes.ctoecskylight.com"' appsettings.json > temp.json && mv temp.json appsettings.json
+            jq '.ClientUris="<< parameters.additional-clients >>https://localhost:5001,https://<< parameters.stage >>.ece-fawkes.ctoecskylight.com"' appsettings.json > temp.json && mv temp.json appsettings.json
             jq '.EnvironmentName="<< parameters.dotnet-env >>"' appsettings.json > temp.json && mv temp.json appsettings.json
             jq '.Logging.LogGroup="/aws/elasticbeanstalk/ece-wingedkeys-<< parameters.stage >>-env/app-log"' appsettings.json > temp.json && mv temp.json appsettings.json
             jq '.Logging.LogLevel.Default="Information"' appsettings.json > temp.json && mv temp.json appsettings.json

--- a/src/WingedKeys/Config.cs
+++ b/src/WingedKeys/Config.cs
@@ -40,25 +40,6 @@ namespace WingedKeys
 			{
 				new ApiResource
 				{
-					Name = "hedwig_backend",
-
-					Description = "Hedwig API",
-
-					// include the following using claims in access token (in addition to subject id)
-					UserClaims = { "role" },
-
-					Scopes =
-					{
-						new Scope()
-						{
-							Name = "hedwig_backend",
-							DisplayName = "Full access to Hedwig API",
-							UserClaims = new [] { "role", "allowed_apps" }
-						}
-					}
-				},
-				new ApiResource
-				{
 					Name = "data_collection_backend",
 
 					Description = "Data Collection API",
@@ -92,12 +73,6 @@ namespace WingedKeys
 			var postLogoutRedirectUris = clientUris;
 			string[] redirectUris = clientUris.Select(uri => $"{uri}{redirectEndpoint}").ToArray();
 
-			string hedwigClientUri = clientUris.Where(uri => uri.Contains("reporter.ecereporterpilot.com")).FirstOrDefault();
-			if (hedwigClientUri == null)
-			{
-				hedwigClientUri = clientUris.Where(uri => uri.Contains("hedwig")).FirstOrDefault();
-			}
-
 			string fawkesClientUri = clientUris.Where(uri => uri.Contains("ece-reporter.ctoec.org")).FirstOrDefault();
 			if (fawkesClientUri == null)
             {
@@ -106,32 +81,6 @@ namespace WingedKeys
 
 			return new List<Client>
 			{
-				// Hedwig Client
-				new Client
-				{
-					ClientId = "hedwig",
-					ClientName = "Hedwig Client",
-					ClientUri = hedwigClientUri,
-
-					AllowedGrantTypes = GrantTypes.Code,
-					RequireClientSecret = false,
-					RequireConsent = false,
-
-					RedirectUris =           redirectUris,
-					PostLogoutRedirectUris = postLogoutRedirectUris,
-					AllowedCorsOrigins =     allowedCorsOrigins,
-
-					AccessTokenLifetime = Int32.Parse(accessTokenLifetime),
-
-					AllowedScopes =
-					{
-						IdentityServerConstants.StandardScopes.OpenId,
-						IdentityServerConstants.StandardScopes.Profile,
-						"hedwig_backend"
-					},
-
-					AllowOfflineAccess = true,
-				},
 				// Data Collection Client
 				new Client
 				{


### PR DESCRIPTION
## Background
This PR removes all handling of Hedwig as an authentication client of Winged Keys.

## GitHub Issue
https://github.com/skylight-hq/ctoec-devops/issues/189

## Associated PRs
https://github.com/skylight-hq/ctoec-devops/pull/210

## Validation Plan
- [x] Confirm the following on QA, where the `clients` table is recreated on deploy
   - [x] Confirm users can still log in to ECE Reporter
   - [x] Confirm Hedwig row is not added to the `clients` table
   - [x] Confirm Forgot Password flow still works
   - [x] Confirm Reset Password flow still works
   - [x] Confirm creating a new user still works
- [x] Confirm the following on devsecure, where the `clients` table is **not** recreated on deploy
   - [x] Confirm users can still log in to ECE Reporter
   - [x] Confirm Forgot Password flow still works
   - [x] Confirm Reset Password flow still works
   - [x] Confirm creating a new user still works