### PR TITLE
Create new automation environment for e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,14 @@ workflows:
           stage: qa
           requires:
             - hold
+  deploy-to-automation:
+    jobs:
+      - hold:
+          type: approval
+      - deploy:
+          stage: automation
+          requires:
+            - hold
   deploy-to-prod:
     jobs:
       - hold:

--- a/src/WingedKeys/.ebextensions/https-instance.config
+++ b/src/WingedKeys/.ebextensions/https-instance.config
@@ -4,7 +4,7 @@ Resources:
       AWS::CloudFormation::Authentication:
         S3Auth:
           type: "s3"
-          buckets: ["ece-wingedkeys-prod-store", "ece-wingedkeys-qa-store", "ece-wingedkeys-staging-store", "ece-wingedkeys-devsecure-store"]
+          buckets: ["ece-wingedkeys-prod-store", "ece-wingedkeys-qa-store", "ece-wingedkeys-staging-store", "ece-wingedkeys-devsecure-store", "ece-wingedkeys-automation-store"]
           roleName: 
             "Fn::GetOptionSetting": 
               Namespace: "aws:autoscaling:launchconfiguration"


### PR DESCRIPTION
## Background
This PR adds support for deploying WingedKeys to our new `automation` environment.

## GitHub Issue
N/A

## Associated PRs
- https://github.com/ctoec/data-collection/pull/1295
- https://github.com/skylight-hq/ctoec-devops/pull/214

## Validation Plan
- [x] WingedKeys is deployed to the new `automation` environment without issue