### PR TITLE
Programmatically add emails to Fawkes users

### DIFF
--- a/src/WingedKeys/Config.cs
+++ b/src/WingedKeys/Config.cs
@@ -46,7 +46,7 @@ namespace WingedKeys
 					Description = "Data Collection API",
 
 					// include the following user claims in access token (in addition to subject id)
-					UserClaims = { "role" },
+					UserClaims = { "role", "email" },
 
 					Scopes =
 					{

--- a/src/WingedKeys/Config.cs
+++ b/src/WingedKeys/Config.cs
@@ -30,6 +30,7 @@ namespace WingedKeys
 			{
 				new IdentityResources.OpenId(),
 				new IdentityResources.Profile(),
+				new IdentityResources.Email(),
 			};
 		}
 
@@ -44,7 +45,7 @@ namespace WingedKeys
 
 					Description = "Data Collection API",
 
-					// include the following using claims in access token (in addition to subject id)
+					// include the following user claims in access token (in addition to subject id)
 					UserClaims = { "role" },
 
 					Scopes =
@@ -102,6 +103,7 @@ namespace WingedKeys
 					{
 						IdentityServerConstants.StandardScopes.OpenId,
 						IdentityServerConstants.StandardScopes.Profile,
+						IdentityServerConstants.StandardScopes.Email,
 						"data_collection_backend"
 					},
 


### PR DESCRIPTION
## Background
Expose the user's email data on the access token upon login, to be used by Fawkes.

## GitHub Issue
https://github.com/ctoec/data-collection/issues/1313

## Associated PRs
https://github.com/ctoec/data-collection/pull/1327