### PR TITLE
Remove all traces of e2e/integration testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,14 +166,6 @@ workflows:
           stage: qa
           requires:
             - hold
-  deploy-to-automation:
-    jobs:
-      - hold:
-          type: approval
-      - deploy:
-          stage: automation
-          requires:
-            - hold
   deploy-to-prod:
     jobs:
       - hold:

--- a/src/WingedKeys/.ebextensions/https-instance.config
+++ b/src/WingedKeys/.ebextensions/https-instance.config
@@ -4,7 +4,7 @@ Resources:
       AWS::CloudFormation::Authentication:
         S3Auth:
           type: "s3"
-          buckets: ["ece-wingedkeys-prod-store", "ece-wingedkeys-qa-store", "ece-wingedkeys-staging-store", "ece-wingedkeys-devsecure-store", "ece-wingedkeys-automation-store"]
+          buckets: ["ece-wingedkeys-prod-store", "ece-wingedkeys-qa-store", "ece-wingedkeys-staging-store", "ece-wingedkeys-devsecure-store"]
           roleName: 
             "Fn::GetOptionSetting": 
               Namespace: "aws:autoscaling:launchconfiguration"


### PR DESCRIPTION
## Background
This PR removes references to our automated testing infrastructure, now that we've done away with our e2e test suite.

## GitHub Issue
N/A

## Associated PRs
- https://github.com/ctoec/data-collection/pull/1384
- https://github.com/skylight-hq/ctoec-devops/pull/217